### PR TITLE
Feat/provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 dist/
+
+.env

--- a/pkg/connector/entitlements.go
+++ b/pkg/connector/entitlements.go
@@ -2,12 +2,12 @@ package connector
 
 const (
 	assignedEntitlement                  = "assigned"
-	readStatsAndAnalyticsEntitlement     = "read stats and analytics"
-	accessBillingEntitlement             = "access billing"
-	manageUsersAndAccountsEntitlement    = "manage users and accounts"
-	readStatsAndConfigurationEntitlement = "read stats and configuration"
-	purgeSelectedContentEntitlement      = "purge selected content"
-	purgeAllEntitlement                  = "purge all"
-	fullAccessEntitlement                = "full access"
+	readStatsAndAnalyticsEntitlement     = "read-stats-and-analytics"
+	accessBillingEntitlement             = "access-billing"
+	manageUsersAndAccountsEntitlement    = "manage-users-and-accounts"
+	readStatsAndConfigurationEntitlement = "read-stats-and-configuration"
+	purgeSelectedContentEntitlement      = "purge-selected-content"
+	purgeAllEntitlement                  = "purge-all"
+	fullAccessEntitlement                = "full-access"
 	accessEntitlement                    = "access"
 )

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -125,6 +125,8 @@ func (o *roleBuilder) Grant(ctx context.Context, principal *v2.Resource, entitle
 			zap.String("principal_id", principal.Id.Resource),
 			zap.String("principal_type", principal.Id.ResourceType),
 		)
+
+		return nil, err
 	}
 
 	role := strings.ToLower(entitlement.Resource.Id.Resource)
@@ -159,6 +161,8 @@ func (o *roleBuilder) Revoke(ctx context.Context, grant *v2.Grant) (annotations.
 			zap.String("principal_id", principal.Id.Resource),
 			zap.String("principal_type", principal.Id.ResourceType),
 		)
+
+		return nil, err
 	}
 
 	role := strings.ToLower(revokedRole)


### PR DESCRIPTION
- Featuring provisioning for Services and Roles. 
- Provisioning for Services is able just for users with Engineer role.
- Revoking the Role resource will set the user role to **User**.
- Revoking Services is done by following the map:
  - **purgeSelectedContentEntitlement** revoked to **readStatsAndConfigurationEntitlement**,
  - **purgeAllEntitlement** revoked to **purgeSelectedContentEntitlement**,
  - **fullAccessEntitlement** revoked to **purgeAllEntitlement**,
  - **readStatsAndConfigurationEntitlement** is not possible since its lowest permission engineer can have

Closes https://github.com/ConductorOne/baton-project-status/issues/66